### PR TITLE
Support of ReactEmptyComponent

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -24,6 +24,7 @@ function patchApi(api){
 
   function isComponentInstance(instance){
     return instance &&
+        instance.element._currentElement &&
         typeof instance.element._currentElement != 'number' &&
         typeof instance.element._currentElement != 'string' &&
         typeof instance.element._currentElement.type != 'string';


### PR DESCRIPTION
Eventually I get error `Uncaught TypeError: Cannot read property 'type' of null` because React have special component type called `ReactEmptyComponent` without `_currentElement`.

![Alt text](https://monosnap.com/file/0K04LzMWyrktEkSEksWU1SMwGI6Jku.png)
